### PR TITLE
shu: change UI for auth login using HTML form

### DIFF
--- a/public/res/css/aton.css
+++ b/public/res/css/aton.css
@@ -189,7 +189,10 @@ canvas:active {
     cursor: -webkit-grabbing;
 }
 
-
+/* convenience class to hide elements  */
+.hide {
+    display: none;
+}
 /*
 .infoContainer {
     position: absolute;
@@ -629,6 +632,18 @@ canvas:active {
 
     margin: 3px;
     padding: 3px;
+}
+
+/* status messages */
+.error {
+    padding: 0.8rem 0;
+    background-color: rgba(127, 0, 0, 0.5);
+    width: 100%;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    font-weight: 900;
+    text-align: center;
 }
 
 /* icon / button */

--- a/public/shu/auth/index.html
+++ b/public/shu/auth/index.html
@@ -44,9 +44,11 @@ let onLoginSuccess = (r)=>{
 };
 
 // Failed
-let onLoginFail = ()=>{
-    $("#idLoginBTN").html("Login FAILED");
-    $("#idLoginBTN").attr("class","atonBTN atonBTN-red");
+const onLoginFail = ()=>{
+    $("#error").addClass("error");
+    $("#error").removeClass("hide");
+    //Reset form
+    $("#loginForm")[0].reset();
 };
 
 let renderAuthForm = (data)=>{
@@ -102,28 +104,33 @@ let renderAuthForm = (data)=>{
     }
     else {
 
-        htmlcontent += "<div class='atonBlockRound' style='width:80%; max-width:500px;'>";
+        htmlcontent += "<div class='hide' id='error'>Wrong user name and/or password</div>";
+        htmlcontent += "<form method='GET' class='atonBlockRound' id='loginForm' style='width:80%; max-width:500px;'>";
         htmlcontent += "username:<input id='idUsername' type='text' maxlength='15' size='15' ><br>";
         htmlcontent += "password:<input id='idPassword' type='password' maxlength='15' size='15' ><br>";
 
-        htmlcontent += "<div class='atonBTN atonBTN-green' style='width:90%' id='idLoginBTN'>LOGIN</div>";
-        htmlcontent += "</div>";
+        htmlcontent += "<button class='atonBTN atonBTN-green' style='width:90%' id='idLoginBTN'>LOGIN</button>";
+        htmlcontent += "</form>";
 
         $("#idUserTitle").html("Authentication");
         $("#idAuth").html(htmlcontent);
 
-        $("#idLoginBTN").click(()=>{
-            let o = {
-                username: $("#idUsername").val(), 
-                password: $("#idPassword").val()
-            };
+	// On form submit, prevent default so page is not reloaded
+	document.querySelector('#loginForm').
+		addEventListener('submit', (e) => {
+		    e.preventDefault();
+        	    let o = {
+                	username: $("#idUsername").val(), 
+	                password: $("#idPassword").val()
+            	     };
 
-            ATON.Utils.postJSON(ATON.PATH_RESTAPI+"login/", o, onLoginSuccess, onLoginFail );
-        });
+            	    ATON.Utils.postJSON(ATON.PATH_RESTAPI+"login/", o, onLoginSuccess, onLoginFail );
+		});
+	
     }
 };
 
-window.addEventListener( 'load', ()=>{
+window.addEventListener('load', ()=>{
 
     SHU.uiAddMainToolbar("idTopToolbar");
 


### PR DESCRIPTION
This PR introduces a simple UI change for the auth page of the SHU backend.
The login is now performed via a standard HTML form - so the inputs are no longer in a `<div>` - with a submit `<button>`.
This enables the browser to submit the login form when the `Enter` key is pressed on a keyboard, so it's not necessary to click on the login button.

When the login fails, the button appearance and inner HTML is not altered; instead, an error message is displayed above the form and the inputs are cleared, like this:

![image](https://user-images.githubusercontent.com/53601706/142771786-05466740-02f1-45ac-a054-3e2ccfde4de6.png)

This could be a more standard behavior for the user. Changing the login button after failure could be confusing.

Source files where changes were made:

```
public/shu/auth/index.html
public/res/css/aton.css
```

Let me know if this is acceptable. I tried following the project's coding style, but I can amend as needed.

